### PR TITLE
Potential Vulnerability in Cloned Code

### DIFF
--- a/thirdparty/stb_image/include/stb_image/stb_image.h
+++ b/thirdparty/stb_image/include/stb_image/stb_image.h
@@ -3246,6 +3246,13 @@ static int stbi__process_frame_header(stbi__jpeg *z, int scan)
 	  if (z->img_comp[i].v > v_max) v_max = z->img_comp[i].v;
    }
 
+   // check that plane subsampling factors are integer ratios; our resamplers can't deal with fractional ratios
+   // and I've never seen a non-corrupted JPEG file actually use them
+   for (i=0; i < s->img_n; ++i) {
+      if (h_max % z->img_comp[i].h != 0) return stbi__err("bad H","Corrupt JPEG");
+      if (v_max % z->img_comp[i].v != 0) return stbi__err("bad V","Corrupt JPEG");
+   }
+
    // compute interleaved mcu info
    z->img_h_max = h_max;
    z->img_v_max = v_max;


### PR DESCRIPTION
This PR fixes a potential security vulnerability in `stbi__process_frame_header` that was cloned from `https://github.com/nothings/stb` but did not receive the security patch.

###Details:
Affected Function: `stbi__process_frame_header` in file `stb_image.h`
Original Fix: `https://github.com/nothings/stb/commit/5ba0baaa269b3fd681828e0e3b3ac0f1472eaf40`


###What this PR does:
This PR applies the same security patch that was applied to the original repository to eliminate the potential vulnerability in the cloned code.

###References:
`https://github.com/nothings/stb/commit/5ba0baaa269b3fd681828e0e3b3ac0f1472eaf40`
`https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2021-28021`

Please review and merge this PR to ensure your repository is protected against this potential vulnerability.”
