### PR TITLE
[codex] Persist share button as select setting

### DIFF
--- a/include/scePadSettings.hpp
+++ b/include/scePadSettings.hpp
@@ -255,6 +255,7 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	triggersAsButtonStartPos,
 	TouchpadAsSelect,
 	TouchpadAsStart,
+	ShareBtnAsSelect,
 	Hidden
 );
 


### PR DESCRIPTION
## What changed

Add `ShareBtnAsSelect` to the JSON serialization list for `s_scePadSettings`.

## Why

`ShareBtnAsSelect` exists in the runtime settings and UI, but was omitted from `NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT`. As a result, `.dsy` files do not save or restore the setting, including files selected as controller defaults.

## Impact

"Share button as select" now persists across configuration save/load and default configuration loading.

## Validation

- Built successfully in x64 Release with MSVC and Ninja.
- Confirmed the generated `.dsy` schema now includes `ShareBtnAsSelect`.
